### PR TITLE
Set Solana network default to testnet

### DIFF
--- a/includes/class-x402-admin.php
+++ b/includes/class-x402-admin.php
@@ -66,7 +66,7 @@ class X402_Admin {
         register_setting('x402_settings', 'x402_solana_network', array(
             'type' => 'string',
             'sanitize_callback' => 'sanitize_text_field',
-            'default' => 'mainnet-beta'
+            'default' => 'testnet'
         ));
         
         register_setting('x402_settings', 'x402_custom_rpc_endpoint', array(
@@ -150,14 +150,15 @@ class X402_Admin {
                             </label>
                         </th>
                         <td>
+                            <?php $current_network = get_option('x402_solana_network', 'testnet'); ?>
                             <select id="x402_solana_network" name="x402_solana_network">
-                                <option value="mainnet-beta" <?php selected(get_option('x402_solana_network', 'mainnet-beta'), 'mainnet-beta'); ?>>
+                                <option value="mainnet-beta" <?php selected($current_network, 'mainnet-beta'); ?>>
                                     <?php echo esc_html__('Mainnet Beta', 'x402-solana-paywall'); ?>
                                 </option>
-                                <option value="testnet" <?php selected(get_option('x402_solana_network'), 'testnet'); ?>>
+                                <option value="testnet" <?php selected($current_network, 'testnet'); ?>>
                                     <?php echo esc_html__('Testnet', 'x402-solana-paywall'); ?>
                                 </option>
-                                <option value="devnet" <?php selected(get_option('x402_solana_network'), 'devnet'); ?>>
+                                <option value="devnet" <?php selected($current_network, 'devnet'); ?>>
                                     <?php echo esc_html__('Devnet', 'x402-solana-paywall'); ?>
                                 </option>
                             </select>

--- a/includes/class-x402-payment.php
+++ b/includes/class-x402-payment.php
@@ -155,7 +155,7 @@ class X402_Payment {
      */
     private static function verify_on_chain($signature, $wallet_address, $merchant_wallet, $required_amount) {
         // Get Solana network configuration
-        $network      = get_option('x402_solana_network', 'mainnet-beta');
+        $network      = get_option('x402_solana_network', 'testnet');
         $rpc_endpoint = self::get_rpc_endpoint($network);
 
         if (empty($rpc_endpoint)) {

--- a/x402-solana-paywall.php
+++ b/x402-solana-paywall.php
@@ -117,7 +117,7 @@ class X402_Solana_Paywall {
      */
     private function set_default_options() {
         $defaults = array(
-            'x402_solana_network' => 'mainnet-beta',
+            'x402_solana_network' => 'testnet',
             'x402_default_currency' => 'SOL',
             'x402_enable_logging' => true,
             'x402_session_timeout' => 3600,


### PR DESCRIPTION
## Summary
- default the Solana network option to testnet for new installs
- update the admin settings form to preselect testnet when no value is saved
- ensure runtime blockchain calls fall back to testnet when no option exists

## Testing
- php -l x402-solana-paywall.php
- php -l includes/class-x402-admin.php
- php -l includes/class-x402-payment.php

------
https://chatgpt.com/codex/tasks/task_b_69003ab661d08332b673ab58ff1feb16