### PR TITLE
Harden WooCommerce gateway validation and AJAX contracts

### DIFF
--- a/AUDIT-WooCommerce.md
+++ b/AUDIT-WooCommerce.md
@@ -1,0 +1,44 @@
+# X402 WooCommerce Gateway Audit
+
+## Summary
+- **Scope**: `includes/class-x402-woocommerce-gateway.php`, supporting utilities (`includes/class-x402-logger.php`, `x402-solana-paywall.php`, `assets/js/frontend.js`).
+- **Focus areas**: runtime stability, security posture, administrative UX, and payment verification flows.
+
+## Critical issues
+1. **Fatal error in checkout renderer**  
+   `payment_fields()` calls an undefined helper `wptautokses_post()`. PHP fatals when WooCommerce renders the gateway form, blocking checkout for every store that enables the method.【F:includes/class-x402-woocommerce-gateway.php†L892-L905】  
+   _Remediation_: Replace the typo with `wp_kses_post()` (or equivalent sanitization) before wrapping in `wpautop()`.
+
+2. **Dynamic logger invocation crashes**  
+   `X402_Logger::log_facilitator_response()` attempts to call `self::$level(...)`. Because `$level` is a string, PHP interprets this as a static property reference and throws a fatal error before any facilitator response can be recorded.【F:includes/class-x402-logger.php†L169-L175】  
+   _Remediation_: Resolve via `call_user_func(array(__CLASS__, $level), ...)` or an explicit `if/else` dispatch to `self::info()` / `self::error()`.
+
+## High issues
+3. **Admin validation runs after options are stored**  
+   Both `process_admin_options()` and `validate_admin_options()` are bound to the same WooCommerce hook with default priority. The save routine executes first, persists whatever was submitted, and only then adds validation errors while still returning success.【F:includes/class-x402-woocommerce-gateway.php†L28-L106】  
+   _Risk_: Invalid pay-to, asset, or facilitator URLs remain saved, undermining subsequent runtime checks. In turn, `maybe_create_facilitator()` can pass unsanitized custom URLs straight into the facilitator client when validation should have prevented this.【F:includes/class-x402-woocommerce-gateway.php†L682-L698】  
+   _Remediation_: Implement `validate_fields()`/`validate_*` accessors or move the validation logic into field-specific callbacks so WooCommerce blocks the save before persisting.
+
+4. **Frontend AJAX contracts are inconsistent**  
+   The localized script exports `verify_nonce`/`status_nonce`, yet the JavaScript expects `x402_ajax.nonce`, and separate routines reference a non-existent `x402_vars` object for the same values. Manual verification requests therefore omit the nonce entirely, leading to 403 responses, and price conversions rely on `x402_ajax.price_nonce` while the backend still checks for `x402_payment_nonce` in other paths.【F:x402-solana-paywall.php†L247-L274】【F:assets/js/frontend.js†L167-L219】【F:assets/js/frontend.js†L299-L337】  
+   _Risk_: Payment verification UX is effectively broken and weakens nonce-based CSRF protection.  
+   _Remediation_: Align PHP localization keys with the JavaScript contract (or vice versa) and ensure every AJAX handler verifies the matching nonce action.
+
+## Medium issues
+5. **Custom facilitator endpoint bypasses URL sanitization**  
+   When the “Custom” facilitator mode is selected, the stored endpoint is passed raw to `FacilitatorClient::selfHosted()` without `esc_url_raw()` or format checks, so malformed URLs survive even when validation should have failed.【F:includes/class-x402-woocommerce-gateway.php†L687-L713】  
+   _Remediation_: Reuse the same sanitizer as `get_facilitator_endpoint()` or call `X402_Crypto_Validator::validate_facilitator_url()` before instantiation.
+
+6. **REST exposure relies solely on WooCommerce order keys**  
+   The `/x402/v1/orders/<id>` route is world-readable (`permission_callback => __return_true`) and only gates access by comparing the supplied `key` parameter with the order key.【F:includes/class-x402-api.php†L63-L133】  
+   _Risk_: Anyone with a leaked order link can continually pull fresh payment payloads. Consider scoping the permission callback (e.g., to the order owner or authenticated facilitators) or rate-limiting/expiring the shared token.
+
+## Low issues & observations
+- Repeated logging sanitization is thorough, but consider redacting wallet addresses before storing in WooCommerce order meta to avoid exposing PII in exports.【F:includes/class-x402-woocommerce-gateway.php†L562-L612】
+- Scheduled cleanup hooks (`x402_cleanup_*`) are registered globally, yet uninstall routines do not unschedule them—worth confirming deactivation cleans up cron entries.【F:x402-solana-paywall.php†L101-L150】
+
+## Suggested next steps
+1. Fix the fatal runtime regressions (items 1 & 2) before shipping any WooCommerce release.
+2. Rework admin validation to happen pre-save and tighten facilitator endpoint sanitization.
+3. Audit every AJAX/REST contract, ensuring localized data, nonce actions, and server checks align.
+4. Revisit REST exposure and logging practices for least-privilege access and data minimization.

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -165,13 +165,18 @@
      * Verify manual payment
      */
     function verifyManualPayment(postId) {
+        if (typeof x402_ajax === 'undefined') {
+            console.error('x402_ajax localization is missing.');
+            return;
+        }
+
         // Trigger AJAX verification
         $.ajax({
-            url: x402_vars.ajax_url,
+            url: x402_ajax.ajax_url,
             type: 'POST',
             data: {
                 action: 'x402_verify_payment',
-                nonce: x402_vars.payment_nonce,
+                _wpnonce: x402_ajax.verify_nonce,
                 post_id: postId
             },
             success: function(response) {
@@ -297,6 +302,11 @@
      * Verify payment
      */
     function verifyPayment() {
+        if (typeof x402_ajax === 'undefined') {
+            console.error('x402_ajax localization is missing.');
+            return;
+        }
+
         var $button = $('#x402-verify-payment');
         var $status = $('.x402-status-message');
         var $walletInput = $('#x402-wallet-address');
@@ -330,7 +340,7 @@
             type: 'POST',
             data: {
                 action: 'x402_verify_payment',
-                nonce: x402_ajax.nonce,
+                _wpnonce: x402_ajax.verify_nonce,
                 post_id: postId,
                 wallet_address: walletAddress,
                 signature: signature

--- a/includes/class-x402-api.php
+++ b/includes/class-x402-api.php
@@ -35,7 +35,7 @@ class X402_API {
      */
     public static function verify_payment() {
         // Verify nonce
-        if (!check_ajax_referer('x402_payment_nonce', 'nonce', false)) {
+        if (!class_exists('X402_Security_Handler') || !X402_Security_Handler::verify_nonce(X402_Security_Handler::VERIFY_PAYMENT_ACTION)) {
             wp_send_json_error(
                 array(
                     'message' => __('Security check failed', 'x402-solana-paywall'),
@@ -86,7 +86,7 @@ class X402_API {
             array(
                 'methods'             => WP_REST_Server::READABLE,
                 'callback'            => array(__CLASS__, 'get_order_payment_request'),
-                'permission_callback' => '__return_true',
+                'permission_callback' => array(__CLASS__, 'can_access_order_payment_request'),
                 'args'                => array(
                     'order_id' => array(
                         'required'          => true,
@@ -167,5 +167,42 @@ class X402_API {
                 'encoded'  => $payload['encoded'],
             )
         );
+    }
+
+    /**
+     * Restrict access to order payment requests exposed over REST.
+     *
+     * @param WP_REST_Request $request Request instance.
+     * @return bool
+     */
+    public static function can_access_order_payment_request(WP_REST_Request $request) {
+        if (!class_exists('WC_Order')) {
+            return current_user_can('manage_woocommerce') || current_user_can('manage_options');
+        }
+
+        $order_id = (int) $request->get_param('order_id');
+        $order    = wc_get_order($order_id);
+
+        if (!$order instanceof WC_Order) {
+            return false;
+        }
+
+        if (class_exists('X402_Security_Handler') && X402_Security_Handler::can_manage_payments()) {
+            return true;
+        }
+
+        $user_id = get_current_user_id();
+
+        if ($user_id > 0 && (int) $order->get_customer_id() === (int) $user_id) {
+            return true;
+        }
+
+        $provided_key = (string) $request->get_param('key');
+
+        if ('' !== $provided_key && hash_equals($order->get_order_key(), $provided_key)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/includes/class-x402-logger.php
+++ b/includes/class-x402-logger.php
@@ -168,11 +168,18 @@ class X402_Logger {
      */
     public static function log_facilitator_response($status_code, $response = array()) {
         $level = $status_code >= 200 && $status_code < 300 ? 'info' : 'error';
-        
-        self::$level('Facilitator response', array(
-            'status_code' => $status_code,
-            'response' => self::sanitize_log_data($response),
-        ));
+
+        if (method_exists(__CLASS__, $level)) {
+            call_user_func(array(__CLASS__, $level), 'Facilitator response', array(
+                'status_code' => $status_code,
+                'response'    => self::sanitize_log_data($response),
+            ));
+        } else {
+            self::info('Facilitator response', array(
+                'status_code' => $status_code,
+                'response'    => self::sanitize_log_data($response),
+            ));
+        }
     }
 
     /**

--- a/includes/class-x402-woocommerce-gateway.php
+++ b/includes/class-x402-woocommerce-gateway.php
@@ -41,68 +41,114 @@ if (!class_exists('X402_WooCommerce_Gateway') && class_exists('WC_Payment_Gatewa
 
             add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
             add_action('woocommerce_order_details_after_order_table', array($this, 'render_order_payment_details'), 20, 1);
-            
-            // Admin validation
-            add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'validate_admin_options'));
         }
 
         /**
-         * Validate admin options before saving.
+         * Process and validate admin options before saving.
          */
-        public function validate_admin_options() {
-            $pay_to = $this->get_option('pay_to');
-            $asset = $this->get_option('asset');
-            $network = $this->get_option('network');
-            $facilitator_endpoint = $this->get_option('facilitator_endpoint');
+        public function process_admin_options() {
+            $post_data = $this->get_post_data();
+            $settings  = $this->collect_posted_settings($post_data);
+            $errors    = $this->validate_settings($settings);
 
-            // Validate pay_to address
-            if (!empty($pay_to) && !X402_Crypto_Validator::validate_solana_address($pay_to) && !X402_Crypto_Validator::validate_eth_address($pay_to)) {
-                WC_Admin_Settings::add_error(__('Invalid pay-to address format.', 'x402-solana-paywall'));
+            if (!empty($errors)) {
+                foreach ($errors as $message) {
+                    WC_Admin_Settings::add_error($message);
+                }
+
+                $this->display_errors();
+                return false;
             }
 
-            // Validate asset address
-            if (!empty($asset) && !X402_Crypto_Validator::validate_solana_address($asset) && !X402_Crypto_Validator::validate_eth_address($asset)) {
-                WC_Admin_Settings::add_error(__('Invalid asset address format.', 'x402-solana-paywall'));
+            $result = parent::process_admin_options();
+
+            if ($result) {
+                X402_Logger::info('Gateway settings validated', array(
+                    'network'          => $settings['network'],
+                    'facilitator_mode' => $settings['facilitator_mode'],
+                    'use_custom_token' => $settings['use_custom_token'],
+                ));
             }
 
-            // Validate facilitator URL
-            if (!empty($facilitator_endpoint) && !X402_Crypto_Validator::validate_facilitator_url($facilitator_endpoint)) {
-                WC_Admin_Settings::add_error(__('Invalid facilitator URL. Must use HTTPS (except for localhost).', 'x402-solana-paywall'));
+            return $result;
+        }
+
+        /**
+         * Collect posted settings in a sanitized array keyed by option name.
+         *
+         * @param array $post_data Raw post data from the settings form.
+         * @return array
+         */
+        private function collect_posted_settings(array $post_data) {
+            $fields = $this->get_form_fields();
+            $get    = function ($key, $default = '') use ($fields, $post_data) {
+                if (!isset($fields[$key])) {
+                    return $default;
+                }
+
+                return $this->get_field_value($key, $fields[$key], $post_data);
+            };
+
+            return array(
+                'pay_to'                  => trim((string) $get('pay_to')),
+                'asset'                   => trim((string) $get('asset')),
+                'network'                 => (string) $get('network', 'solana-devnet'),
+                'facilitator_endpoint'    => trim((string) $get('facilitator_endpoint')),
+                'facilitator_mode'        => (string) $get('facilitator_mode', 'base'),
+                'use_custom_token'        => (string) $get('use_custom_token', 'no'),
+                'custom_token_ca'         => trim((string) $get('custom_token_ca')),
+                'custom_token_symbol'     => trim((string) $get('custom_token_symbol')),
+                'custom_token_decimals'   => $get('custom_token_decimals', ''),
+            );
+        }
+
+        /**
+         * Validate submitted settings prior to saving.
+         *
+         * @param array $settings Sanitized settings array.
+         * @return string[] List of validation error messages.
+         */
+        private function validate_settings(array $settings) {
+            $errors = array();
+
+            if (!empty($settings['pay_to']) && !X402_Crypto_Validator::validate_solana_address($settings['pay_to']) && !X402_Crypto_Validator::validate_eth_address($settings['pay_to'])) {
+                $errors[] = __('Invalid pay-to address format.', 'x402-solana-paywall');
             }
 
-            // Validate custom token if enabled
-            $use_custom = $this->get_option('use_custom_token');
-            if ($use_custom === 'yes') {
-                $custom_ca = $this->get_option('custom_token_ca');
-                $custom_symbol = $this->get_option('custom_token_symbol');
-                $custom_decimals = $this->get_option('custom_token_decimals');
-                
-                if (empty($custom_ca)) {
-                    WC_Admin_Settings::add_error(__('Custom token contract address (CA) is required when custom token is enabled.', 'x402-solana-paywall'));
+            if (!empty($settings['asset']) && !X402_Crypto_Validator::validate_solana_address($settings['asset']) && !X402_Crypto_Validator::validate_eth_address($settings['asset'])) {
+                $errors[] = __('Invalid asset address format.', 'x402-solana-paywall');
+            }
+
+            if (!empty($settings['facilitator_endpoint']) && !X402_Crypto_Validator::validate_facilitator_url($settings['facilitator_endpoint'])) {
+                $errors[] = __('Invalid facilitator URL. Must use HTTPS (except for localhost).', 'x402-solana-paywall');
+            }
+
+            if ('yes' === $settings['use_custom_token']) {
+                if (empty($settings['custom_token_ca'])) {
+                    $errors[] = __('Custom token contract address (CA) is required when custom token is enabled.', 'x402-solana-paywall');
                 }
-                
-                if (empty($custom_symbol)) {
-                    WC_Admin_Settings::add_error(__('Custom token symbol is required.', 'x402-solana-paywall'));
+
+                if (empty($settings['custom_token_symbol'])) {
+                    $errors[] = __('Custom token symbol is required.', 'x402-solana-paywall');
                 }
-                
-                if (empty($custom_decimals) || $custom_decimals < 0 || $custom_decimals > 18) {
-                    WC_Admin_Settings::add_error(__('Custom token decimals must be between 0 and 18.', 'x402-solana-paywall'));
+
+                $decimals = '' === $settings['custom_token_decimals'] ? null : (int) $settings['custom_token_decimals'];
+
+                if (null === $decimals || $decimals < 0 || $decimals > 18) {
+                    $errors[] = __('Custom token decimals must be between 0 and 18.', 'x402-solana-paywall');
                 }
-                
-                // Validate CA format
-                $is_valid_ca = X402_Crypto_Validator::validate_eth_address($custom_ca) || 
-                               X402_Crypto_Validator::validate_solana_address($custom_ca);
-                
-                if (!$is_valid_ca) {
-                    WC_Admin_Settings::add_error(__('Invalid contract address format. Must be a valid Ethereum (0x...) or Solana (base58) address.', 'x402-solana-paywall'));
+
+                if (!empty($settings['custom_token_ca'])) {
+                    $is_valid_ca = X402_Crypto_Validator::validate_eth_address($settings['custom_token_ca']) ||
+                                   X402_Crypto_Validator::validate_solana_address($settings['custom_token_ca']);
+
+                    if (!$is_valid_ca) {
+                        $errors[] = __('Invalid contract address format. Must be a valid Ethereum (0x...) or Solana (base58) address.', 'x402-solana-paywall');
+                    }
                 }
             }
 
-            X402_Logger::info('Gateway settings validated', array(
-                'network' => $network,
-                'facilitator_mode' => $this->get_option('facilitator_mode'),
-                'use_custom_token' => $use_custom,
-            ));
+            return $errors;
         }
 
         /**
@@ -691,8 +737,18 @@ if (!class_exists('X402_WooCommerce_Gateway') && class_exists('WC_Payment_Gatewa
                     throw new ValidationException(__('Custom facilitator endpoint is required when using the Custom Facilitator option.', 'x402-solana-paywall'));
                 }
 
+                if (!X402_Crypto_Validator::validate_facilitator_url($endpoint)) {
+                    throw new ValidationException(__('Custom facilitator endpoint must be a valid HTTPS URL (localhost allowed).', 'x402-solana-paywall'));
+                }
+
+                $sanitized_endpoint = esc_url_raw($endpoint, array('http', 'https'));
+
+                if ('' === $sanitized_endpoint) {
+                    throw new ValidationException(__('Custom facilitator endpoint is not a valid URL.', 'x402-solana-paywall'));
+                }
+
                 $api_key = $this->get_option('facilitator_api_key');
-                return FacilitatorClient::selfHosted($endpoint, $api_key ? (string) $api_key : null);
+                return FacilitatorClient::selfHosted($sanitized_endpoint, $api_key ? (string) $api_key : null);
             }
 
             return null;
@@ -891,7 +947,7 @@ if (!class_exists('X402_WooCommerce_Gateway') && class_exists('WC_Payment_Gatewa
          */
         public function payment_fields() {
             if ($this->description) {
-                echo wpautop(wptautokses_post($this->description));
+                echo wpautop(wp_kses_post($this->description));
             }
             
             // Display custom token info if enabled


### PR DESCRIPTION
## Summary
- validate WooCommerce gateway settings before saving and harden custom facilitator URL handling
- align frontend AJAX nonce usage with localized data and tighten REST permission checks
- fix dynamic logger invocation to avoid fatal errors when logging facilitator responses

## Testing
- php -l includes/class-x402-woocommerce-gateway.php
- php -l includes/class-x402-logger.php
- php -l includes/class-x402-api.php

------
https://chatgpt.com/codex/tasks/task_b_69023bd18d3c8332a7cd16b76041ce68